### PR TITLE
[🧪] idで検索時に存在しない場合、nullを返す

### DIFF
--- a/src/modules/user/user.resolver.ts
+++ b/src/modules/user/user.resolver.ts
@@ -27,11 +27,15 @@ export class UserResolver {
     return await this.userService.findAllUsers();
   }
 
-  @Query(() => User)
+  @Query(() => User, { nullable: true })
   async user(
     @Args('id', { type: () => ID }, ValidationPipe) id: string,
   ): Promise<User> {
-    return await this.userService.findUserById(id);
+    try {
+      return await this.userService.findUserById(id);
+    } catch {
+      return null;
+    }
   }
 
   // create user


### PR DESCRIPTION
単純に、try-catchの`catch`時に`return null`にする